### PR TITLE
Bug Fix: Trimming Whitespace for User Inputs for Clues

### DIFF
--- a/frontend/src/components/BuildCrossword/CreateCrossword.tsx
+++ b/frontend/src/components/BuildCrossword/CreateCrossword.tsx
@@ -249,7 +249,7 @@ export default function CreateCrossword(props: CreateCrosswordProps) {
     direction: string,
     index: number
   ): void => {
-    const value: string = event.target.value;
+    const value: string = event.target.value.trim();
 
     const newAcrossValues: string[] = [...acrossClueValues].map((val) => {
       return val;


### PR DESCRIPTION
Currently, when creating/editing crossword clues, the user inputs are not trimmed. This PR adds `trim()` to take care of any whitespace.

<img width="504" height="403" alt="Screenshot 2025-07-22 at 10 28 01 PM" src="https://github.com/user-attachments/assets/2f1a446f-f8b1-4c23-90f5-37df829af05f" />
